### PR TITLE
Describes pipelines in the Boutiques format

### DIFF
--- a/carmin.yaml
+++ b/carmin.yaml
@@ -316,7 +316,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/boutiques/boutiques/master/tools/python/boutiques/schema/descriptor.schema.json'
+                $ref: 'http://raw.githubusercontent.com/boutiques/boutiques/0.5.7/tools/python/boutiques/schema/descriptor.schema.json'
         default: 
           $ref: '#/components/responses/Error'
   /path/{completePath}:

--- a/carmin.yaml
+++ b/carmin.yaml
@@ -1,6 +1,6 @@
 openapi: '3.0.0'
 info:
-  version: '0.4'
+  version: '0.2.2'
   title: CARMIN - Common API for Research Medical Imaging Network
   description: REST API for exchanging data and remotely calling pipelines.
   license:
@@ -298,7 +298,27 @@ paths:
               schema:
                 $ref: '#/components/schemas/Pipeline'
         default: 
-          $ref: '#/components/responses/Error'      
+          $ref: '#/components/responses/Error'
+  /pipelines/{pipelineIdentifier}/boutiquesdescriptor:
+    get:
+      summary: Returns the Boutiques descriptor of the pipeline, if available. 
+      operationId: getBoutiquesDescriptor
+      parameters:
+      - name: pipelineIdentifier
+        in: path
+        required: true
+        schema:
+          type: string
+          format: ascii
+      responses:
+        '200':
+          description: successful response
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/boutiques/boutiques/master/tools/python/boutiques/schema/descriptor.schema.json'
+        default: 
+          $ref: '#/components/responses/Error'
   /path/{completePath}:
     get:
       summary: get content or various information
@@ -533,8 +553,61 @@ components:
           type: string
     Pipeline:
       type: object
-      $ref: 'https://raw.githubusercontent.com/boutiques/boutiques/master/tools/python/boutiques/schema/descriptor.schema.json'
-      example: 'https://raw.githubusercontent.com/boutiques/boutiques/master/tools/python/boutiques/schema/examples/good.json'
+      required:
+        - identifier
+        - name
+        - version
+        - properties
+        # - parameters optional in 0.2
+      properties:
+        identifier:
+          type: string
+          format: ascii
+        name:
+          type: string
+        version:
+          type: string
+          format: ascii
+        description:
+          type: string
+        canExecute:
+          type: boolean
+          description: true if the user who requested the pipeline can execute it
+        parameters:
+          type: array
+          items:
+            $ref: '#/components/schemas/PipelineParameter'
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+          description: the properties (as keys) and their values that describe the pipeline. 
+            The properties used must be listed in the "supportedPipelineProperties" of the "getPlatformProperties" method.
+        errorCodesAndMessages:
+          type: array
+          items:
+            $ref: '#/components/schemas/ErrorCodeAndMessage'
+    PipelineParameter:
+      type: object
+      required:
+        - name
+        - type
+        - isOptional
+        - isReturnedValue
+      properties:
+        name:
+          type: string
+          format: ascii
+        type:
+          $ref: '#/components/schemas/ParameterType'
+        isOptional:
+          type: boolean
+        isReturnedValue:
+          type: boolean
+        defaultValue:
+          description: Default value. It must be consistent with the parameter type.
+        description:
+          type: string
     ParameterType:
       type: string
       enum: [File,String,Boolean,Int64,Double,List]

--- a/carmin.yaml
+++ b/carmin.yaml
@@ -316,7 +316,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'http://raw.githubusercontent.com/boutiques/boutiques/0.5.7/tools/python/boutiques/schema/descriptor.schema.json'
+                $ref: 'http://raw.githubusercontent.com/boutiques/boutiques/0.5.8/tools/python/boutiques/schema/descriptor.schema.json'
         default: 
           $ref: '#/components/responses/Error'
   /path/{completePath}:

--- a/carmin.yaml
+++ b/carmin.yaml
@@ -1,6 +1,6 @@
 openapi: '3.0.0'
 info:
-  version: '0.2.2'
+  version: '0.4'
   title: CARMIN - Common API for Research Medical Imaging Network
   description: REST API for exchanging data and remotely calling pipelines.
   license:
@@ -532,61 +532,8 @@ components:
           type: string
     Pipeline:
       type: object
-      required:
-        - identifier
-        - name
-        - version
-        - properties
-        # - parameters optional in 0.2
-      properties:
-        identifier:
-          type: string
-          format: ascii
-        name:
-          type: string
-        version:
-          type: string
-          format: ascii
-        description:
-          type: string
-        canExecute:
-          type: boolean
-          description: true if the user who requested the pipeline can execute it
-        parameters:
-          type: array
-          items:
-            $ref: '#/components/schemas/PipelineParameter'
-        properties:
-          type: object
-          additionalProperties:
-            type: string
-          description: the properties (as keys) and their values that describe the pipeline. 
-            The properties used must be listed in the "supportedPipelineProperties" of the "getPlatformProperties" method.
-        errorCodesAndMessages:
-          type: array
-          items:
-            $ref: '#/components/schemas/ErrorCodeAndMessage'
-    PipelineParameter:
-      type: object
-      required:
-        - name
-        - type
-        - isOptional
-        - isReturnedValue
-      properties:
-        name:
-          type: string
-          format: ascii
-        type:
-          $ref: '#/components/schemas/ParameterType'
-        isOptional:
-          type: boolean
-        isReturnedValue:
-          type: boolean
-        defaultValue:
-          description: Default value. It must be consistent with the parameter type.
-        description:
-          type: string
+      $ref: 'https://raw.githubusercontent.com/boutiques/boutiques/master/tools/python/boutiques/schema/descriptor.schema.json'
+      example: 'https://raw.githubusercontent.com/boutiques/boutiques/master/tools/python/boutiques/schema/examples/good.json'
     ParameterType:
       type: string
       enum: [File,String,Boolean,Int64,Double,List]


### PR DESCRIPTION
As discussed in #61. 

- Pipeline objects are now defined through a reference to the [Boutiques](https://github.com/boutiques/boutiques) specification (latest stable release). PipelineParameter does not exist any more.
- Boutiques has been updated to support tags and error messages. 
- Migrating from the existing pipeline format to Boutiques should be straightforward. Here is a minimal Boutiques descriptor:
```
{
  "name": "echo",
  "tool-version": "1.0",
  "description": "A simple script to test output files",
  "command-line": "echo [PARAM] > output.txt",
  "schema-version": "0.5",
  "inputs": [{
      "id": "param",
      "name": "Parameter",
      "value-key": "[PARAM]",
      "type": "Number"
  }],
  "output-files": [{
      "id": "output_file",
      "name": "Output file",
      "path-template": "output.txt"
  }]
}
```
- This opens the door to pipeline import/export through CARMIN since Boutiques supports executable pipelines, i.e., pipelines linked to container images.
- Pipelines can be validated and executed using `bosh`, the Boutiques shell:
  - `pip install boutiques`
  - `bosh validate <pipeline.json>`
  - `bosh exec launch <pipeline.json> <invocation.json>`
- @axlbonnet The pipeline example I added to the `pipelines/{pipelineIdentifier}` method doesn't show in SwaggerUI. I'm not sure why, maybe you'll have an idea.