### PR TITLE
Minor language tune ups in the summary/description in carmin.yaml

### DIFF
--- a/carmin.yaml
+++ b/carmin.yaml
@@ -15,7 +15,7 @@ security:
 paths:
   /platform:
     get:
-      summary: Returns information about the platform
+      summary: Return information about the platform
       description: 
         https must be supported in the list of the supported protocols.
       operationId: getPlatformProperties
@@ -31,7 +31,7 @@ paths:
           $ref: '#/components/responses/Error'
   /authenticate:
     post:
-      summary: Returns the api key necessary to use the API.
+      summary: Return the API key necessary to use the API.
       description:
          The key can be dynamic (a new one for each request) or static (always the same one until the user change it in a back-end)
       operationId: authenticate
@@ -53,9 +53,9 @@ paths:
             $ref: '#/components/responses/Error'
   /executions:
     get:
-      summary: Lists some executions.
+      summary: List some executions.
       description:
-        list all execution Ids in the platform which are ordered in decreasing submission time.
+        List all execution Ids in the platform which are ordered in decreasing submission time.
         All the executions that were launched by the user must be returned. It is up to the platform to return executions that the user did not launch.
         When studyIdentifier is present, all the executions that the user launched in the study must be returned.
       operationId: listExecutions
@@ -84,7 +84,7 @@ paths:
         default:
           $ref: '#/components/responses/Error'
     post:
-      summary: Initializes an execution
+      summary: Initialize an execution
       description:
         The successful response must contain the execution identifier. 
         If the status “Initializing” is returned, playExecution must be called to start the execution.
@@ -106,7 +106,7 @@ paths:
           $ref: '#/components/responses/Error'
   /executions/count:
     get:
-      summary: Give the number of the user's executions
+      summary: Get the number of the user's executions
       operationId: countExecutions
       parameters:
       - name: studyIdentifier
@@ -126,7 +126,7 @@ paths:
     parameters:
     - $ref: '#/components/parameters/PathExecutionIdentifier'
     get:
-      summary: get information about an execution
+      summary: Get information about an execution
       operationId: getExecution
       responses:
         '200':
@@ -138,7 +138,7 @@ paths:
         default:
           $ref: '#/components/responses/Error'
     put:
-      summary: Modify an execution. 
+      summary: Modify an execution.
       description:
         Only the name and the timeout of the execution can be modified. 
         Changes to the identifier or the status will raise errors. 
@@ -173,7 +173,7 @@ paths:
           $ref: '#/components/responses/Error'
   /executions/{executionIdentifier}/results:
     get:
-      summary: get the result files of the execution
+      summary: Get the result files of the execution
       operationId: getExecutionResults
       parameters:
       - $ref: '#/components/parameters/PathExecutionIdentifier'
@@ -195,7 +195,7 @@ paths:
           $ref: '#/components/responses/Error'
   /executions/{executionIdentifier}/stdout:
     get:
-      summary: get stdout of an execution
+      summary: Get stdout of an execution
       operationId: getStdout
       parameters:
       - $ref: '#/components/parameters/PathExecutionIdentifier'
@@ -210,7 +210,7 @@ paths:
           $ref: '#/components/responses/Error'
   /executions/{executionIdentifier}/stderr:
     get:
-      summary: get stderr of an execution
+      summary: Get stderr of an execution
       operationId: getStderr
       parameters:
       - $ref: '#/components/parameters/PathExecutionIdentifier'
@@ -225,7 +225,7 @@ paths:
           $ref: '#/components/responses/Error'
   /executions/{executionIdentifier}/play:
     put:
-      summary: play an execution
+      summary: Play an execution
       operationId: playExecution
       parameters:
       - $ref: '#/components/parameters/PathExecutionIdentifier'
@@ -236,7 +236,7 @@ paths:
           $ref: '#/components/responses/Error'
   /executions/{executionIdentifier}/kill:
     put:
-      summary: kill an execution
+      summary: Kill an execution
       operationId: killExecution
       parameters:
       - $ref: '#/components/parameters/PathExecutionIdentifier'
@@ -298,15 +298,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Pipeline'
-        default: 
-          $ref: '#/components/responses/Error'      
+        default:
+          $ref: '#/components/responses/Error'
   /path/{completePath}:
     get:
-      summary: get content or various information
+      summary: Get content or information for a given path
       description:
-        Allow file downloading and give access to multiple information about a specific path. 
-        The response format and content depends on the mandatory action query parameter (see the parameter description). 
-        Basically, the "content" action downloads the raw file, and the other actions return various informations in json.
+        Download a file (or a directory) or retun information about a specific path.
+        The response format and content depends on the mandatory action query parameter (see the parameter description).
+        Basically, the "content" action downloads the raw file, and the other actions return various information in a JSON record.
       operationId: getPath
       parameters:
       - name: completePath
@@ -612,7 +612,7 @@ components:
         timeout:
           type: integer
           format: int64
-          description: The timeout in seconds until which the execution is killed and deleted with all its files. 0 or absense means no timeout
+          description: The timeout in seconds until which the execution is killed and deleted with all its files. 0 or absence means no timeout
         status:
           type: string
           enum: [Initializing,Ready,Running,Finished,InitializationFailed,ExecutionFailed,Unknown,Killed]


### PR DESCRIPTION
Feel free to ignore/close.  I just fixed up some things while trying to grasp the spec
- Consistent imperative form and casing in `summary`
- A few (not all) trailing spaces removed
- Some sentences rewording to make them more (Russian) English